### PR TITLE
perf: improve tag check regex performance

### DIFF
--- a/tag_checking.go
+++ b/tag_checking.go
@@ -3,7 +3,7 @@ package docxtpl
 import "regexp"
 
 func textContainsTags(text string) (bool, error) {
-	r, err := regexp.Compile("{{.+}}")
+	r, err := regexp.Compile("{{.*?}}")
 	if err != nil {
 		return false, err
 	}

--- a/tag_checking.go
+++ b/tag_checking.go
@@ -1,19 +1,35 @@
 package docxtpl
 
-import "regexp"
+import (
+	"regexp"
+	"sync"
+)
+
+var tagRegex *regexp.Regexp
+var tagOnce sync.Once
 
 func textContainsTags(text string) (bool, error) {
-	r, err := regexp.Compile("{{.*?}}")
+	var err error
+	tagOnce.Do(func() {
+		tagRegex, err = regexp.Compile("{{.*?}}")
+	})
 	if err != nil {
 		return false, err
 	}
-	return r.MatchString(text), err
+
+	return tagRegex.MatchString(text), err
 }
 
+var incompleteTagRegex *regexp.Regexp
+var incompleteTagOnce sync.Once
+
 func textContainsIncompleteTags(text string) (bool, error) {
-	r, err := regexp.Compile("{{[^}]*?(}$|$)|{$|^}")
+	var err error
+	incompleteTagOnce.Do(func() {
+		incompleteTagRegex, err = regexp.Compile("{{[^}]*?(}$|$)|{$|^}")
+	})
 	if err != nil {
 		return false, err
 	}
-	return r.MatchString(text), err
+	return incompleteTagRegex.MatchString(text), err
 }

--- a/tag_checking.go
+++ b/tag_checking.go
@@ -11,7 +11,7 @@ func textContainsTags(text string) (bool, error) {
 }
 
 func textContainsIncompleteTags(text string) (bool, error) {
-	r, err := regexp.Compile("{{[^}]*(}$|$)|{$|^}")
+	r, err := regexp.Compile("{{[^}]*?(}$|$)|{$|^}")
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
I found some performance wins in the way that we use regexes for type checking

* There were opportunities to do lazy checking
* Only compile the regexps once using `sync.Once` rather than recompiling on each function call