### PR TITLE
feat!: parse from filename and reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,9 @@ import (
 )
 
 func main() {
-  // Parse the document
-  doc, err := docxtpl.Parse("template.docx")
+  // Parse the document 
+  // If using a reader, use docxtpl.Parse instead
+  doc, err := docxtpl.ParseFromFilename("template.docx")
   if err != nil {
     panic(err)
   }

--- a/docxtpl.go
+++ b/docxtpl.go
@@ -12,58 +12,43 @@ import (
 
 type DocxTmpl struct {
 	*docx.Docx
-	filename     string
 	contentTypes *ContentTypes
+}
+
+// Parse the document from a reader and store it in memory.
+func Parse(reader io.ReaderAt, size int64) (*DocxTmpl, error) {
+	doc, err := docx.Parse(reader, size)
+	if err != nil {
+		return nil, err
+	}
+
+	contentTypes, err := getContentTypes(reader, size)
+	if err != nil {
+		return nil, err
+	}
+
+	return &DocxTmpl{doc, contentTypes}, nil
 }
 
 // Parse the document from a filename and store it in memory.
 func ParseFromFilename(filename string) (*DocxTmpl, error) {
-	readFile, err := os.Open(filename)
+	reader, err := os.Open(filename)
 	if err != nil {
 		return nil, err
 	}
 
-	fileinfo, err := readFile.Stat()
+	fileinfo, err := reader.Stat()
 	if err != nil {
 		return nil, err
 	}
 	size := fileinfo.Size()
-	doc, err := docx.Parse(readFile, size)
+
+	doxtpl, err := Parse(reader, size)
 	if err != nil {
 		return nil, err
 	}
 
-	contentTypes, err := getContentTypes(readFile, size)
-	if err != nil {
-		return nil, err
-	}
-
-	return &DocxTmpl{doc, filename, contentTypes}, nil
-}
-
-// Parse the document from a filename and store it in memory.
-func Parse(filename string) (*DocxTmpl, error) {
-	readFile, err := os.Open(filename)
-	if err != nil {
-		return nil, err
-	}
-
-	fileinfo, err := readFile.Stat()
-	if err != nil {
-		return nil, err
-	}
-	size := fileinfo.Size()
-	doc, err := docx.Parse(readFile, size)
-	if err != nil {
-		return nil, err
-	}
-
-	contentTypes, err := getContentTypes(readFile, size)
-	if err != nil {
-		return nil, err
-	}
-
-	return &DocxTmpl{doc, filename, contentTypes}, nil
+	return doxtpl, nil
 }
 
 // Replace the placeholders in the document with passed in data.

--- a/docxtpl.go
+++ b/docxtpl.go
@@ -16,7 +16,32 @@ type DocxTmpl struct {
 	contentTypes *ContentTypes
 }
 
-// Parse the document and store it in memory from a filename.
+// Parse the document from a filename and store it in memory.
+func ParseFromFilename(filename string) (*DocxTmpl, error) {
+	readFile, err := os.Open(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	fileinfo, err := readFile.Stat()
+	if err != nil {
+		return nil, err
+	}
+	size := fileinfo.Size()
+	doc, err := docx.Parse(readFile, size)
+	if err != nil {
+		return nil, err
+	}
+
+	contentTypes, err := getContentTypes(readFile, size)
+	if err != nil {
+		return nil, err
+	}
+
+	return &DocxTmpl{doc, filename, contentTypes}, nil
+}
+
+// Parse the document from a filename and store it in memory.
 func Parse(filename string) (*DocxTmpl, error) {
 	readFile, err := os.Open(filename)
 	if err != nil {

--- a/docxtpl_test.go
+++ b/docxtpl_test.go
@@ -117,7 +117,7 @@ func TestParseAndRender(t *testing.T) {
 	})
 
 	t.Run("Document with image structs", func(t *testing.T) {
-		doc, err := Parse("test_templates/test_with_tables_and_images.docx")
+		doc, err := ParseFromFilename("test_templates/test_with_tables_and_images.docx")
 		if err != nil {
 			t.Fatalf("%v - Parsing error: %v", t.Name(), err)
 		}
@@ -198,7 +198,7 @@ func parseAndRender(t *testing.T, filename string, data interface{}) {
 
 	// Parse the document
 	parseStart := time.Now()
-	doc, err := Parse("test_templates/" + filename)
+	doc, err := ParseFromFilename("test_templates/" + filename)
 	if err != nil {
 		t.Fatalf("%v - Parsing error: %v", t.Name(), err)
 	}


### PR DESCRIPTION
This changes the `Parse` function to instead accept `reader` and `size` parameters instead of a filename to make it more flexible. A new `ParseFromFilename` function is provided for convenience.