### PR TITLE
refactor: Remove redundant reassignment in Go routines

### DIFF
--- a/tag_merging.go
+++ b/tag_merging.go
@@ -10,7 +10,6 @@ func mergeTags(items []any) {
 	var wg sync.WaitGroup
 
 	for _, item := range items {
-		item := item
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
@@ -64,7 +63,6 @@ func mergeTagsInTable(table *docx.Table) {
 	for _, row := range table.TableRows {
 		for _, cell := range row.TableCells {
 			for _, paragraph := range cell.Paragraphs {
-				paragraph := paragraph
 				wg.Add(1)
 				go func() {
 					defer wg.Done()

--- a/tag_merging_test.go
+++ b/tag_merging_test.go
@@ -130,10 +130,16 @@ func TestMergeTagsInParagraph(t *testing.T) {
 func TestMergeTagsInTable(t *testing.T) {
 	assert := assert.New(t)
 
-	startText := docx.Text{
-		Text: "{{ .tag ",
+	p1StartText := docx.Text{
+		Text: "{{ .tag1 ",
 	}
-	endText := docx.Text{
+	p1EndText := docx.Text{
+		Text: "}}",
+	}
+	p2StartText := docx.Text{
+		Text: "{{ .tag2 ",
+	}
+	p2EndText := docx.Text{
 		Text: "}}",
 	}
 	tbl := docx.Table{
@@ -146,8 +152,18 @@ func TestMergeTagsInTable(t *testing.T) {
 								Children: []any{
 									&docx.Run{
 										Children: []any{
-											&startText,
-											&endText,
+											&p1StartText,
+											&p1EndText,
+										},
+									},
+								},
+							},
+							{
+								Children: []any{
+									&docx.Run{
+										Children: []any{
+											&p2StartText,
+											&p2EndText,
 										},
 									},
 								},
@@ -161,6 +177,8 @@ func TestMergeTagsInTable(t *testing.T) {
 
 	mergeTagsInTable(&tbl)
 
-	assert.Equal(startText.Text, "")
-	assert.Equal(endText.Text, "{{ .tag }}")
+	assert.Equal(p1StartText.Text, "")
+	assert.Equal(p1EndText.Text, "{{ .tag1 }}")
+	assert.Equal(p2StartText.Text, "")
+	assert.Equal(p2EndText.Text, "{{ .tag2 }}")
 }


### PR DESCRIPTION
Post Go 1.22, you no longer need to reassign variables used in Go routines due to this version changing variable capture in loops.