### PR TITLE
chore: Update Go to v1.25 and set minimum supported to v1.24

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,6 +17,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
+          cache: true
 
       - name: Install gotestsum
         run: go install gotest.tools/gotestsum@latest

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -26,7 +26,7 @@ jobs:
           mkdir -p test-results
           gotestsum \
             --format testname \
-            --junitfile test-results/tests_${{ matrix.go-version }}.xml \
+            --junitfile test-results/tests.xml \
             -- \
             -race \
             -cover \

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -35,5 +35,5 @@ jobs:
       - name: Upload test results
         uses: actions/upload-artifact@v4
         with:
-          name: test-results
-          path: test-results/tests_${{ matrix.go-version }}.xml
+          name: test-results-go-${{ matrix.go-version }}
+          path: test-results/tests.xml

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ["1.24", "1.25"]
+        go-version: ["1.24.x", "1.25.x"]
 
     steps:
       - name: Checkout code
@@ -17,9 +17,6 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go-version }}
-
-      - name: Verify Go version
-        run: go version
 
       - name: Install gotestsum
         run: go install gotest.tools/gotestsum@latest

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -19,7 +19,7 @@ jobs:
           go-version: ${{ matrix.go-version }}
 
       - name: Verify Go version
-      - run: go version
+        run: go version
 
       - name: Install gotestsum
         run: go install gotest.tools/gotestsum@latest

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ["1.23.x"]
+        go-version: ["1.24.x", "1.25.x"]
 
     steps:
       - name: Checkout code

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -26,7 +26,7 @@ jobs:
           mkdir -p test-results
           gotestsum \
             --format testname \
-            --junitfile test-results/tests.xml \
+            --junitfile test-results/tests_${{ matrix.go-version }}.xml \
             -- \
             -race \
             -cover \
@@ -36,4 +36,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: test-results
-          path: test-results/tests.xml
+          path: test-results/tests_${{ matrix.go-version }}.xml

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -7,17 +7,19 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ["1.24.x", "1.25.x"]
+        go-version: ["1.24", "1.25"]
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go-version }}
-          cache: true
+
+      - name: Verify Go version
+      - run: go version
 
       - name: Install gotestsum
         run: go install gotest.tools/gotestsum@latest

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,7 +17,6 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
-          cache: true
 
       - name: Install gotestsum
         run: go install gotest.tools/gotestsum@latest

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tomwatkins1994/go-docx-template
 
-go 1.23.2
+go 1.25.5
 
 require (
 	github.com/bep/imagemeta v0.8.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/tomwatkins1994/go-docx-template
 
-go 1.25.5
+go 1.24
+
+toolchain go1.25.5
 
 require (
 	github.com/bep/imagemeta v0.8.1


### PR DESCRIPTION
Fixes #61 

* Min Go version updated to `v1.24` in line with Go support
* Go toolchain version updated to `v1.25.5`
* Tests now run on both `v1.24` and `v1.25` - the supported versions at the time of this PR
* Tests for `v1.23` removed as this is not supported anymore